### PR TITLE
Set Client host explicitly

### DIFF
--- a/spec/fleet_app/client_wrapper_spec.cr
+++ b/spec/fleet_app/client_wrapper_spec.cr
@@ -1,0 +1,18 @@
+require "../spec_helper"
+
+describe FleetApp::ClientWrapper do
+  describe "#new" do
+    it "Client returns the correct host" do
+      FleetApp::ClientWrapper.new("production").client.host.should eq(FleetAppClient::HOST)
+      FleetApp::ClientWrapper.new("staging").client.host.should eq(FleetAppClient::SANDBOX_HOST)
+      FleetApp::ClientWrapper.new("sandbox").client.host.should eq(FleetAppClient::SANDBOX_HOST)
+      FleetApp::ClientWrapper.new("test").client.host.should eq(FleetAppClient::DEVELOPMENT_HOST)
+      FleetApp::ClientWrapper.new("development").client.host.should eq(FleetAppClient::DEVELOPMENT_HOST)
+    end
+
+    it "uses the Client passed in the constructor" do
+      client = FleetApp::Client.new(FleetAppClient::SANDBOX_HOST)
+      FleetApp::ClientWrapper.new("production", client).client.host.should eq(FleetAppClient::SANDBOX_HOST)
+    end
+  end
+end

--- a/src/fleet_app/client_wrapper.cr
+++ b/src/fleet_app/client_wrapper.cr
@@ -1,7 +1,9 @@
 module FleetApp
   # Wraps over the client's response bodies and returns result objects.
   class ClientWrapper
-    def initialize(environment : String, client : FleetApp::Client? = nil)
+    getter client : FleetApp::Client
+
+    def initialize(@environment : String, client : FleetApp::Client? = nil)
       @environment = environment
 
       if client
@@ -9,10 +11,14 @@ module FleetApp
         @client = client.not_nil!
       else
         # Instantiate a client based on the environment passed in
-        if @environment == "production"
+        case @environment
+        when "production"
           @client = FleetApp::Client.new
-        else
+        when "staging", "sandbox"
           @client = FleetApp::Client.new(FleetAppClient::SANDBOX_HOST)
+        else
+          # use localhost for "test" and "development" environments
+          @client = FleetApp::Client.new(FleetAppClient::DEVELOPMENT_HOST)
         end
       end
     end

--- a/src/fleet_app/client_wrapper.cr
+++ b/src/fleet_app/client_wrapper.cr
@@ -3,7 +3,7 @@ module FleetApp
   class ClientWrapper
     getter client : FleetApp::Client
 
-    def initialize(@environment : String, client : FleetApp::Client? = nil)
+    def initialize(environment : String, client : FleetApp::Client? = nil)
       @environment = environment
 
       if client

--- a/src/fleet_app_client.cr
+++ b/src/fleet_app_client.cr
@@ -2,9 +2,9 @@ require "json"
 require "http/client"
 
 class FleetAppClient
-  VERSION      = "0.2.2"
-  HOST         = "fleet.hostari.com"
-  SANDBOX_HOST = "sandbox-#{HOST}"
+  VERSION          = "0.2.2"
+  HOST             = "fleet.hostari.com"
+  SANDBOX_HOST     = "sandbox-#{HOST}"
   DEVELOPMENT_HOST = "localhost:2450"
 end
 

--- a/src/fleet_app_client.cr
+++ b/src/fleet_app_client.cr
@@ -5,6 +5,7 @@ class FleetAppClient
   VERSION      = "0.2.2"
   HOST         = "fleet.hostari.com"
   SANDBOX_HOST = "sandbox-#{HOST}"
+  DEVELOPMENT_HOST = "localhost:2450"
 end
 
 require "./fleet_app/**"


### PR DESCRIPTION
In order to avoid sending commands to Brooce (during “development”), we have to edit fleet_app_client directly from lib and this is not good in terms of DX. We also [miss out on test coverage](https://github.com/hostari/GamesSite/blob/main/spec/models/rust_server_builder_spec.cr) when doing this. This PR sets the client url explicitly to resolve aforementioned issues.