### PR TITLE
Refactor ApiPath

### DIFF
--- a/spec/fleet_app/api_path_spec.cr
+++ b/spec/fleet_app/api_path_spec.cr
@@ -7,28 +7,33 @@ describe FleetApp::ApiPath do
       api_path.path.should eq("/api/v1/valheim/servers/1?queue_name=sample.host")
     end
     it "returns the correct path when initialized with only an action" do
-      api_path = FleetApp::ApiPath.new("valheim", "1", "sample.host", action: "stop")
+      api_path = FleetApp::ApiPath.new("valheim", "1", "sample.host", "stop")
       api_path.path.should eq("/api/v1/valheim/servers/1/stop?queue_name=sample.host")
     end
     it "returns the correct path when initialized with an action and a username" do
-      api_path = FleetApp::ApiPath.new("valheim", "1", "sample.host", action: "stop", username: "testuser1")
+      api_path = FleetApp::ApiPath.new("valheim", "1", "sample.host", "stop", params: {"username" => "testuser1"})
       api_path.path.should eq("/api/v1/valheim/servers/1/stop?queue_name=sample.host&username=testuser1")
     end
     it "returns the correct path when initialized with only a username" do
-      api_path = FleetApp::ApiPath.new("valheim", "1", "sample.host", username: "testuser1")
+      api_path = FleetApp::ApiPath.new("valheim", "1", "sample.host", params: {"username" => "testuser1"})
       api_path.path.should eq("/api/v1/valheim/servers/1?queue_name=sample.host&username=testuser1")
     end
     it "returns the correct path when initialized with a username and a world" do
-      api_path = FleetApp::ApiPath.new("valheim", "1", "sample.host", username: "testuser1", world_name: "World1")
+      api_path = FleetApp::ApiPath.new("valheim", "1", "sample.host", params: {"username" => "testuser1", "world_name" => "World1"})
       api_path.path.should eq("/api/v1/valheim/servers/1?queue_name=sample.host&username=testuser1&world_name=World1")
     end
     it "returns the correct path when initialized with an action and a username and a world" do
-      api_path = FleetApp::ApiPath.new("valheim", "1", "sample.host", action: "start", username: "testuser1", world_name: "World1")
+      api_path = FleetApp::ApiPath.new("valheim", "1", "sample.host", "start", params: {"username" => "testuser1", "world_name" => "World1"})
       api_path.path.should eq("/api/v1/valheim/servers/1/start?queue_name=sample.host&username=testuser1&world_name=World1")
     end
     it "returns the correct path when initialized with only a world" do
-      api_path = FleetApp::ApiPath.new("valheim", "1", "sample.host", world_name: "World1")
+      api_path = FleetApp::ApiPath.new("valheim", "1", "sample.host", params: {"world_name" => "World1"})
       api_path.path.should eq("/api/v1/valheim/servers/1?queue_name=sample.host&world_name=World1")
+    end
+    it "returns the correct path when initialized with arbitrary parameters" do
+      params = {"param1" => "random_param", "foo" => "bar", "fizz" => "buzz"}
+      api_path = FleetApp::ApiPath.new("valheim", "1", "sample.host", params: params)
+      api_path.path.should eq("/api/v1/valheim/servers/1?queue_name=sample.host&param1=random_param&foo=bar&fizz=buzz")
     end
   end
 end

--- a/spec/fleet_app/api_path_spec.cr
+++ b/spec/fleet_app/api_path_spec.cr
@@ -27,8 +27,8 @@ describe FleetApp::ApiPath do
       api_path.path.should eq("/api/v1/valheim/servers/1/start?queue_name=sample.host&username=testuser1&world_name=World1")
     end
     it "returns the correct path when initialized with only a world" do
-      api_path = FleetApp::ApiPath.new("valheim", "1", "sample.host", params: {"world_name" => "World1"})
-      api_path.path.should eq("/api/v1/valheim/servers/1?queue_name=sample.host&world_name=World1")
+      api_path = FleetApp::ApiPath.new("valheim", "1", "sample.host", params: {"world_name" => "World 1"})
+      api_path.path.should eq("/api/v1/valheim/servers/1?queue_name=sample.host&world_name=World+1")
     end
     it "returns the correct path when initialized with arbitrary parameters" do
       params = {"param1" => "random_param", "foo" => "bar", "fizz" => "buzz"}

--- a/spec/fleet_app/server_spec.cr
+++ b/spec/fleet_app/server_spec.cr
@@ -211,7 +211,7 @@ describe FleetApp::Server do
       root_path = "https://fleet.hostari.com"
       queue_name = "sample.host"
       world_name = "world numbah 1"
-      WebMock.stub(:post, "#{root_path}/api/v1/project_zomboid/servers/#{server_id}/wipe_world?queue_name=#{queue_name}&username=#{server_id}&world_name=#{world_name}")
+      WebMock.stub(:post, "#{root_path}/api/v1/project_zomboid/servers/#{server_id}/wipe_world?queue_name=#{queue_name}&username=#{server_id}&world_name=#{URI.encode_path(world_name)}")
         .with(body: "", headers: {"X-Auth-Token" => ""})
         .to_return(status: 200, body: File.read("spec/support/project_zomboid/servers/create.json"))
       result = FleetApp::Server.wipe_world(queue_name, "project_zomboid", server_id, environment: "production", username: server_id, world_name: world_name)

--- a/src/fleet_app/api_path.cr
+++ b/src/fleet_app/api_path.cr
@@ -3,7 +3,7 @@ module FleetApp
     getter path : String
 
     API_VERSION = "v1"
-    BASE_PATH = "/api/#{API_VERSION}"
+    BASE_PATH   = "/api/#{API_VERSION}"
 
     def initialize(game_name : String, server_id : String, @host : String, action : String? = nil, params : Hash(String, String) = {} of String => String)
       if !action.nil?

--- a/src/fleet_app/api_path.cr
+++ b/src/fleet_app/api_path.cr
@@ -13,10 +13,13 @@ module FleetApp
       end
     end
 
+    # returns the query string generated from `params`
     private def query_string(params : Hash(String, String))
       params = URI::Params.build do |form|
+        # queue_name is always included
         form.add "queue_name", @host
         params.each do |param, value|
+          # only add non-empty strings
           form.add param, value if !value.empty?
         end
       end

--- a/src/fleet_app/api_path.cr
+++ b/src/fleet_app/api_path.cr
@@ -1,64 +1,23 @@
 module FleetApp
   class ApiPath
-    def initialize(game_name : String, server_id : String, host : String, world_name : String = "", username : String = "", action : String = "")
-      if username == ""
-        if world_name == ""
-          if action == ""
-            @path = "/api/#{API_VERSION}/#{game_name}/servers/#{server_id}?queue_name=#{host}"
-          else
-            @path = "/api/#{API_VERSION}/#{game_name}/servers/#{server_id}/#{action}?queue_name=#{host}"
-          end
-        else
-          if action == ""
-            @path = "/api/#{API_VERSION}/#{game_name}/servers/#{server_id}?queue_name=#{host}&world_name=#{world_name}"
-          else
-            @path = "/api/#{API_VERSION}/#{game_name}/servers/#{server_id}/#{action}?queue_name=#{host}&world_name=#{world_name}"
-          end
-        end
-      else
-        if world_name == ""
-          if action == ""
-            @path = "/api/#{API_VERSION}/#{game_name}/servers/#{server_id}?queue_name=#{host}&username=#{username}"
-          else
-            @path = "/api/#{API_VERSION}/#{game_name}/servers/#{server_id}/#{action}?queue_name=#{host}&username=#{username}"
-          end
-        else
-          if action == ""
-            @path = "/api/#{API_VERSION}/#{game_name}/servers/#{server_id}?queue_name=#{host}&username=#{username}&world_name=#{world_name}"
-          else
-            @path = "/api/#{API_VERSION}/#{game_name}/servers/#{server_id}/#{action}?queue_name=#{host}&username=#{username}&world_name=#{world_name}"
-          end
-        end
-      end
-    end
-  end
-
-  class ApiPathV2
     getter path : String
 
     API_VERSION = "v1"
     BASE_PATH = "/api/#{API_VERSION}"
 
-    def initialize(game_name : String, server_id : String, @host : String)
-      raw_path = "#{BASE_PATH}/#{game_name}/servers/#{server_id}?queue_name=#{@host}"
-      @path = URI.encode_path(raw_path)
+    def initialize(game_name : String, server_id : String, @host : String, action : String? = nil, params : Hash(String, String) = {} of String => String)
+      if !action.nil?
+        @path = "#{BASE_PATH}/#{game_name}/servers/#{server_id}/#{action}?#{query_string(params)}"
+      else
+        @path = "#{BASE_PATH}/#{game_name}/servers/#{server_id}?#{query_string(params)}"
+      end
     end
 
-    def initialize(game_name : String, server_id : String, @host : String, options : NamedTuple(action: String))
-      raw_path = "#{BASE_PATH}/#{game_name}/servers/#{server_id}/#{options[:action]}?queue_name=#{host}"
-      @path = URI.encode_path(raw_path)
-    end
-
-    def initialize(game_name : String, server_id : String, @host : String, options : NamedTuple(action: String, params: Hash(String, String)))
-      raw_path = "#{BASE_PATH}/#{game_name}/servers/#{server_id}/#{options[:action]}?#{query_string(options)}"
-      @path = URI.encode_path(raw_path)
-    end
-
-    private def query_string(options : NamedTuple(action: String, params: Hash(String, String)))
+    private def query_string(params : Hash(String, String))
       params = URI::Params.build do |form|
         form.add "queue_name", @host
-        options[:params].each do |param, value|
-          form.add param, value
+        params.each do |param, value|
+          form.add param, value if !value.empty?
         end
       end
       params

--- a/src/fleet_app/create.cr
+++ b/src/fleet_app/create.cr
@@ -21,7 +21,7 @@ module FleetApp
     def self.create(host : String, game_name : String, server_id : String, body : String = "", environment : String = "production", username : String = "")
       FleetApp::ClientWrapper.new(environment).post(
         game_name: game_name,
-        path: ApiPath.new(game_name, server_id, host, username).path,
+        path: ApiPath.new(game_name, server_id, host, params: {"username" => username}).path,
         body: body
       )
     end
@@ -29,7 +29,7 @@ module FleetApp
     def self.create_with_auth(host : String, game_name : String, server_id : String, basic_auth : String, body : String = "", environment : String = "production", username : String = "")
       FleetApp::ClientWrapper.new(environment).post_with_auth(
         game_name: game_name,
-        path: ApiPath.new(game_name, server_id, host, username).path,
+        path: ApiPath.new(game_name, server_id, host, params: {"username" => username}).path,
         body: body,
         basic_auth: basic_auth
       )

--- a/src/fleet_app/delete.cr
+++ b/src/fleet_app/delete.cr
@@ -21,7 +21,7 @@ module FleetApp
     def self.delete(host : String, game_name : String, server_id : String, body : String = "", environment : String = "production", username : String = "")
       FleetApp::ClientWrapper.new(environment).post(
         game_name: game_name,
-        path: ApiPath.new(game_name, server_id, host, username: username, action: "delete").path,
+        path: ApiPath.new(game_name, server_id, host, "delete", {"username" => username}).path,
         body: body
       )
     end
@@ -29,7 +29,7 @@ module FleetApp
     def self.delete_with_auth(host : String, game_name : String, server_id : String, basic_auth : String, body : String = "", environment : String = "production", username : String = "")
       FleetApp::ClientWrapper.new(environment).post_with_auth(
         game_name: game_name,
-        path: ApiPath.new(game_name, server_id, host, username: username, action: "delete").path,
+        path: ApiPath.new(game_name, server_id, host, "delete", {"username" => username}).path,
         body: body,
         basic_auth: basic_auth
       )

--- a/src/fleet_app/get_game_id.cr
+++ b/src/fleet_app/get_game_id.cr
@@ -14,7 +14,7 @@ module FleetApp
     # or a `server_id` from VSH.
     #
     # `environment` is an optional string that specifies which fleet app to send the request to.
-    def self.get_game_id(host : String, game_name : String, server_id : String, environment : String = "production")
+    def self.get_game_id(host : String, game_name : String, server_id : String, body : String = "", environment : String = "production")
       FleetApp::ClientWrapper.new(environment).get(
         game_name: game_name,
         path: ApiPath.new(game_name, server_id, host, action: "game_id").path

--- a/src/fleet_app/install_oxide.cr
+++ b/src/fleet_app/install_oxide.cr
@@ -24,7 +24,7 @@ module FleetApp
     def self.install_oxide(host : String, game_name : String, server_id : String, body : String = "", environment : String = "production", username : String = "")
       FleetApp::ClientWrapper.new(environment).post(
         game_name: game_name,
-        path: ApiPath.new(game_name, server_id, host, username: username, action: "install_oxide").path,
+        path: ApiPath.new(game_name, server_id, host, "install_oxide", {"username" => username}).path,
         body: body
       )
     end
@@ -32,7 +32,7 @@ module FleetApp
     def self.install_oxide_with_auth(host : String, game_name : String, server_id : String, basic_auth : String, body : String = "", environment : String = "production", username : String = "")
       FleetApp::ClientWrapper.new(environment).post_with_auth(
         game_name: game_name,
-        path: ApiPath.new(game_name, server_id, host, username: username, action: "install_oxide").path,
+        path: ApiPath.new(game_name, server_id, host, "install_oxide", {"username" => username}).path,
         body: body,
         basic_auth: basic_auth
       )

--- a/src/fleet_app/restart.cr
+++ b/src/fleet_app/restart.cr
@@ -24,7 +24,7 @@ module FleetApp
     def self.restart(host : String, game_name : String, server_id : String, body : String = "", environment : String = "production", username : String = "")
       FleetApp::ClientWrapper.new(environment).post(
         game_name: game_name,
-        path: ApiPath.new(game_name, server_id, host, username: username, action: "restart").path,
+        path: ApiPath.new(game_name, server_id, host, "restart", {"username" => username}).path,
         body: body
       )
     end
@@ -32,7 +32,7 @@ module FleetApp
     def self.restart_with_auth(host : String, game_name : String, server_id : String, basic_auth : String, body : String = "", environment : String = "production", username : String = "")
       FleetApp::ClientWrapper.new(environment).post_with_auth(
         game_name: game_name,
-        path: ApiPath.new(game_name, server_id, host, username: username, action: "restart").path,
+        path: ApiPath.new(game_name, server_id, host, "restart", {"username" => username}).path,
         body: body,
         basic_auth: basic_auth
       )

--- a/src/fleet_app/start.cr
+++ b/src/fleet_app/start.cr
@@ -24,7 +24,7 @@ module FleetApp
     def self.start(host : String, game_name : String, server_id : String, body : String = "", environment : String = "production", username : String = "")
       FleetApp::ClientWrapper.new(environment).post(
         game_name: game_name,
-        path: ApiPath.new(game_name, server_id, host, username: username, action: "start").path,
+        path: ApiPath.new(game_name, server_id, host, "start", {"username" => username}).path,
         body: body
       )
     end
@@ -32,7 +32,7 @@ module FleetApp
     def self.start_with_auth(host : String, game_name : String, server_id : String, basic_auth : String, body : String = "", environment : String = "production", username : String = "")
       FleetApp::ClientWrapper.new(environment).post_with_auth(
         game_name: game_name,
-        path: ApiPath.new(game_name, server_id, host, username: username, action: "start").path,
+        path: ApiPath.new(game_name, server_id, host, "start", {"username" => username}).path,
         body: body,
         basic_auth: basic_auth
       )

--- a/src/fleet_app/stop.cr
+++ b/src/fleet_app/stop.cr
@@ -23,7 +23,7 @@ module FleetApp
     def self.stop(host : String, game_name : String, server_id : String, body : String = "", environment : String = "production", username : String = "")
       FleetApp::ClientWrapper.new(environment).post(
         game_name: game_name,
-        path: ApiPath.new(game_name, server_id, host, username: username, action: "stop").path,
+        path: ApiPath.new(game_name, server_id, host, "stop", {"username" => username}).path,
         body: body
       )
     end
@@ -31,7 +31,7 @@ module FleetApp
     def self.stop_with_auth(host : String, game_name : String, server_id : String, basic_auth : String, body : String = "", environment : String = "production", username : String = "")
       FleetApp::ClientWrapper.new(environment).post_with_auth(
         game_name: game_name,
-        path: ApiPath.new(game_name, server_id, host, username: username, action: "stop").path,
+        path: ApiPath.new(game_name, server_id, host, "stop", {"username" => username}).path,
         body: body,
         basic_auth: basic_auth
       )

--- a/src/fleet_app/update.cr
+++ b/src/fleet_app/update.cr
@@ -24,7 +24,7 @@ module FleetApp
     def self.update(host : String, game_name : String, server_id : String, body : String = "", environment : String = "production", username : String = "")
       FleetApp::ClientWrapper.new(environment).post(
         game_name: game_name,
-        path: ApiPath.new(game_name, server_id, host, username: username, action: "update").path,
+        path: ApiPath.new(game_name, server_id, host, "update", {"username" => username}).path,
         body: body
       )
     end
@@ -32,7 +32,7 @@ module FleetApp
     def self.update_with_auth(host : String, game_name : String, server_id : String, basic_auth : String, body : String = "", environment : String = "production", username : String = "")
       FleetApp::ClientWrapper.new(environment).post_with_auth(
         game_name: game_name,
-        path: ApiPath.new(game_name, server_id, host, username: username, action: "update").path,
+        path: ApiPath.new(game_name, server_id, host, "update", {"username" => username}).path,
         body: body,
         basic_auth: basic_auth
       )

--- a/src/fleet_app/wipe_world.cr
+++ b/src/fleet_app/wipe_world.cr
@@ -24,7 +24,7 @@ module FleetApp
     def self.wipe_world(host : String, game_name : String, server_id : String, body : String = "", environment : String = "production", username : String = "", world_name : String = "")
       FleetApp::ClientWrapper.new(environment).post(
         game_name: game_name,
-        path: ApiPath.new(game_name, server_id, host, "wipe_world", {"username" => username, "world_name" => standardize_world_name(world_name)}).path,
+        path: ApiPath.new(game_name, server_id, host, "wipe_world", {"username" => username, "world_name" => world_name}).path,
         body: body
       )
     end
@@ -32,14 +32,10 @@ module FleetApp
     def self.wipe_world_with_auth(host : String, game_name : String, server_id : String, basic_auth : String, body : String = "", environment : String = "production", username : String = "", world_name : String = "")
       FleetApp::ClientWrapper.new(environment).post_with_auth(
         game_name: game_name,
-        path: ApiPath.new(game_name, server_id, host, "wipe_world", {"username" => username, "world_name" => standardize_world_name(world_name)}).path,
+        path: ApiPath.new(game_name, server_id, host, "wipe_world", {"username" => username, "world_name" => world_name}).path,
         body: body,
         basic_auth: basic_auth
       )
-    end
-
-    def self.standardize_world_name(world_name)
-      URI.encode_path(world_name)
     end
   end
 end

--- a/src/fleet_app/wipe_world.cr
+++ b/src/fleet_app/wipe_world.cr
@@ -24,7 +24,7 @@ module FleetApp
     def self.wipe_world(host : String, game_name : String, server_id : String, body : String = "", environment : String = "production", username : String = "", world_name : String = "")
       FleetApp::ClientWrapper.new(environment).post(
         game_name: game_name,
-        path: ApiPathV2.new(game_name, server_id, host, {action: "wipe_world", params: {"username" => username, "world_name" => world_name}}).path,
+        path: ApiPath.new(game_name, server_id, host, "wipe_world", {"username" => username, "world_name" => standardize_world_name(world_name)}).path,
         body: body
       )
     end
@@ -32,7 +32,7 @@ module FleetApp
     def self.wipe_world_with_auth(host : String, game_name : String, server_id : String, basic_auth : String, body : String = "", environment : String = "production", username : String = "", world_name : String = "")
       FleetApp::ClientWrapper.new(environment).post_with_auth(
         game_name: game_name,
-        path: ApiPath.new(game_name, server_id, host, username: username, action: "wipe_world", world_name: standardize_world_name(world_name)).path,
+        path: ApiPath.new(game_name, server_id, host, "wipe_world", {"username" => username, "world_name" => standardize_world_name(world_name)}).path,
         body: body,
         basic_auth: basic_auth
       )


### PR DESCRIPTION
As we add more actions and params, if-elses could get messy. This generates dynamic path given params (as Hashes) and an action. 

URI::Params also encodes the query string under the hood.

world_name = Project Zomboid Server 6M_Ys

```sh
web          | POST /api/v1/project_zomboid/servers/28f1317a-649c-4987-8238-c8c96b2b9033/wipe_world?queue_name=2013197.xyz&username=pzserver28f1317a-1664949895&world_name=Project+Zomboid+Server+6M_Ys
web          |  ▸ Handled by Api::V1::ProjectZomboid::Servers::WipeWorld
web          |  ▸ Sent 200 OK (424.12µs)
web          |
web          | Compiling...
web          |  Done  compiling
web          | Listening on http://127.0.0.1:2450
web          | command # => "sudo service pzserver28f1317a-1664949895 stop && sudo rm -rf /home/pzserver28f1317a-1664949895/Zomboid/Saves/Multiplayer/Project_Zomboid_Server_6M_Ys && sudo service pzserver28f1317a-1664949895 start && sleep 240 && curl -X POST http://localhost:2450/api/v1/project_zomboid/servers/28f1317a-649c-4987-8238-c8c96b2b9033/restart_complete"
```