### PR TITLE
Add extract_hash method

### DIFF
--- a/src/fleet_app/brooce_command/create.cr
+++ b/src/fleet_app/brooce_command/create.cr
@@ -1,7 +1,7 @@
 module FleetApp
   class Server
     class BrooceCommand
-      # Sends a brooce command to be executed.
+      # Sends a brooce command to be executed for a server.
       #
       # Use `host` to specify the queue name in brooce to send to.
       # For example, use `2013191.xyz` if the command should be executed on tms1.

--- a/src/fleet_app/extract_hash.cr
+++ b/src/fleet_app/extract_hash.cr
@@ -1,0 +1,34 @@
+module FleetApp
+  class ModLibrary
+    # Downloads a mod as a zip file from a library (e.g. Thunderstore) into /srv/{mod_library} folder of tms7,
+    # unzips the file, and walks through each of the directories to extract the sha256 hashes from each file.
+
+    # Host will always be tms7 and does not require a server_id.
+    #
+    # Use `game_name` to specify the game you are sending a brooce command for.
+    # See: `FleetApp::Game` for possible values.
+    #
+    # `body` is an optional, JSON-formatted string that is sent as the request body which defaults to an empty string.
+    # This is used to override the default command in fleet app.
+    # For example, you can send this: `{command: "echo 'foobar'"}.to_json`
+    #
+    # `environment` is an optional string that specifies which fleet app to send the request to.
+
+    def self.extract_hash(host : String, command : String = "", environment : String = "production", username : String = "")
+      FleetApp::ClientWrapper.new(environment).post(
+        game_name: game_name,
+        path: "/api/v1/mod_library/brooce_command?queue_name=#{host}",
+        body: {command: command}.to_json
+      )
+    end
+
+    def self.extract_hash_with_auth(host : String, basic_auth : String, command : String = "", environment : String = "production", username : String = "")
+      FleetApp::ClientWrapper.new(environment).post_with_auth(
+        game_name: game_name,
+        path: "/api/v1/mod_library/brooce_command?queue_name=#{host}",
+        body: {command: command}.to_json,
+        basic_auth: basic_auth
+      )
+    end
+  end
+end

--- a/src/fleet_app/extract_hash.cr
+++ b/src/fleet_app/extract_hash.cr
@@ -4,10 +4,7 @@ module FleetApp
     # unzips the file, and walks through each of the directories to extract the sha256 hashes from each file.
 
     # Host will always be tms7 and does not require a server_id.
-    #
-    # Use `game_name` to specify the game you are sending a brooce command for.
-    # See: `FleetApp::Game` for possible values.
-    #
+
     # `body` is an optional, JSON-formatted string that is sent as the request body which defaults to an empty string.
     # This is used to override the default command in fleet app.
     # For example, you can send this: `{command: "echo 'foobar'"}.to_json`


### PR DESCRIPTION
The `extract_hash` method will be responsible for accepting a command that zips and downloads a file from a URL into the `/srv` folder of tms7, unzips and walks through each of the files to extract the sha256. 

Related to this PR: https://github.com/hostari/valheimserverhosting/pull/746